### PR TITLE
 $(selector) must return with length=0 if no elements found for true jQuery behavior

### DIFF
--- a/backbone.native.js
+++ b/backbone.native.js
@@ -229,8 +229,15 @@
                 div.removeChild(div.firstChild);
                 this.length = 1;
             } else {
-                this[0] = context.querySelector(element);
-                this.length = 1;
+                element = context.querySelector(element);
+                
+                // Length must be 0 if no elements found
+                if (element !== null){
+                    this[0] = element;
+                    this.length = 1;
+                } else {
+                    this.length = 0;
+                }
             }
         } else {
             // This handles both the 'Element' and 'Window' case, as both support


### PR DESCRIPTION
Current result of `$('#non-existent-element')` is:

``` js
{
    [0]: null,
    length: 1
}
```

whereas jQuery would respond:

``` js
{
    length: 0
}
```

I have modified the `$()` function accordingly to accommodate the expected behavior.
